### PR TITLE
CI: complète le déploiement sur GitHub Pages

### DIFF
--- a/.github/workflows/export-mastodon-list.yml
+++ b/.github/workflows/export-mastodon-list.yml
@@ -16,6 +16,12 @@ env:
   LC_ALL: "fr_FR.UTF-8"
   LC_TIME: "fr_FR.UTF-8"
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+
+  
 jobs:
 
   run:

--- a/.github/workflows/export-mastodon-list.yml
+++ b/.github/workflows/export-mastodon-list.yml
@@ -42,8 +42,16 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v4
-
+        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main')
+  
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
+        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main')
         with:
-          path: mastodon/export-mastodon
+          path: mastodon/export-mastodon/
+  
+      - name: Deploy to GitHub Pages
+        id: deployment
+        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main')
+        uses: actions/deploy-pages@v4
+  


### PR DESCRIPTION
- ajoute les permissions nécessaires
- ajoute des conditions pour ne déployer que sur main et en cas de git tag