### PR TITLE
ci: ajoute la permission manquante id-token: write

### DIFF
--- a/.github/workflows/export-mastodon-list.yml
+++ b/.github/workflows/export-mastodon-list.yml
@@ -19,6 +19,7 @@ env:
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
+  id-token: write
   pages: write
 
   


### PR DESCRIPTION
comme indiqué https://github.com/geotribu/geo-mastodon-comptes-listes/actions/runs/8217257002/job/22472757119#step:7:32