### PR TITLE
Add pages directory listing in workflow

### DIFF
--- a/.github/workflows/export-mastodon-list.yml
+++ b/.github/workflows/export-mastodon-list.yml
@@ -50,7 +50,12 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v4
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main')
-  
+
+      - name: Generate Directory Listings
+        uses: jayanta525/github-pages-directory-listing@v4.0.0
+        with:
+          FOLDER: mastodon/export-mastodon/
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main')


### PR DESCRIPTION
Pour éviter de tomber sur la 404 sur la GitHub page https://geotribu.github.io/geo-mastodon-comptes-listes/

:eyes: https://github.com/marketplace/actions/github-pages-directory-listing

À tester